### PR TITLE
Fix build

### DIFF
--- a/lib/hdlc/HDLC.h
+++ b/lib/hdlc/HDLC.h
@@ -21,8 +21,8 @@
 #include <string.h>
 
 #define HDLC_TEMPLATE                                                          \
-        int16_t (&readByte)(void),                                             \
-        void (&writeByte)(uint8_t data),                                       \
+        int16_t (*readByte)(void),                                             \
+        void (*writeByte)(uint8_t data),                                       \
         uint16_t rxBuffLen,                                                    \
         class CRC
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,3 +12,5 @@
 platform = atmelavr
 board = micro
 framework = arduino
+lib_deps =
+    paulstoffregen/OneWire@2.3.5


### PR DESCRIPTION
The OneWire library dependency was missing.

There was also a bizarre C++ compilation issue which is probably linked with a previous bug in GCC which was fixed in the meantime. Turns out that forward references cannot be used in conjunction with function pointers when used as template variables.